### PR TITLE
Correct Python versions in docs.

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -4,7 +4,7 @@ pytket-aqt
 ``pytket-aqt`` is an extension to ``pytket`` that allows ``pytket`` circuits to be
 executed on AQT's quantum devices and simulators.
 
-``pytket-aqt`` is available for Python 3.8, 3.9 and 3.10, on Linux, MacOS and
+``pytket-aqt`` is available for Python 3.10 and 3.11, on Linux, MacOS and
 Windows. To install, run:
 
 ::


### PR DESCRIPTION
I note that Python 3.9 was dropped in https://github.com/CQCL/pytket-aqt/pull/25, presumably because it wasn't working?