### PR TITLE
Use ${{github.workspace}} in constraint file path

### DIFF
--- a/.github/workflows/nox-session.yml
+++ b/.github/workflows/nox-session.yml
@@ -92,12 +92,12 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=dev-tool-requirements.txt poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/dev-tool-requirements.txt poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=dev-tool-requirements.txt nox
+          pipx install --pip-args=--constraint=${{ github.workspace }}/dev-tool-requirements.txt nox
           nox --version
 
       - name: Compute pre-commit cache key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,12 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=dev-tool-requirements.txt poetry
+          pipx install --pip-args=--constraint=${{ github.workspace }}/dev-tool-requirements.txt poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=dev-tool-requirements.txt nox
+          pipx install --pip-args=--constraint=${{ github.workspace }}/dev-tool-requirements.txt nox
           nox --version
 
       - name: Build wheel

--- a/docs/build-docs
+++ b/docs/build-docs
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import argparse
-import datetime
+from datetime import date
 import shutil
 import subprocess
 import sys
@@ -67,7 +67,7 @@ def build_module_docs() -> None:
             "-D",
             f"project=pytket-{MODULE}",
             "-D",
-            f"copyright={datetime.date.today().year} Cambridge Quantum Computing",
+            f"copyright={date.today().year} Cambridge Quantum Computing",
             "-D",
             f"version={'.'.join(v[:2])}",
             "-D",


### PR DESCRIPTION
# Description

Uses absolute path to `dev-tool-requirements.txt` on the CI.
Also fixes weird pylint error that went unnoticed because last PRs were force merged

# Related issues
 fixes #94

# Checklist

- [x] I have performed a self-review of my code.
- ~[] I have commented hard-to-understand parts of my code.~
- ~[ ] I have made corresponding changes to the public API documentation.~
- ~[ ] I have added tests that prove my fix is effective or that my feature works.~
-  ~[] I have updated the changelog with any user-facing changes.~
