### PR TITLE
pin qiskit-aqt-provider to version 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ types-requests = "*"
 pydantic = "^2.0"
 networkx = "^3.0"
 sympy = ">=1.6"
-qiskit-aqt-provider = "^1.3.0"
+qiskit-aqt-provider = "1.5.0"
 
 [tool.poetry.group.tests]
 optional = true

--- a/pytket/extensions/aqt/multi_zone_architecture/circuit/multizone_circuit.py
+++ b/pytket/extensions/aqt/multi_zone_architecture/circuit/multizone_circuit.py
@@ -18,9 +18,9 @@ from copy import deepcopy
 from dataclasses import dataclass
 from dataclasses import field
 from enum import Enum
-from typing import Any, Optional, Iterator
+from typing import Any, Optional, Iterator, TypeAlias
 
-from sympy import symbols, Expr
+from sympy import symbols, Expr  # type: ignore
 
 from pytket.circuit import UnitID
 from pytket.circuit import Circuit
@@ -35,7 +35,7 @@ from ..macro_architecture_graph import empty_macro_arch_from_architecture
 from ..macro_architecture_graph import MultiZoneMacroArch
 from ..macro_architecture_graph import ZoneId
 
-ParamType = Expr | float
+ParamType: TypeAlias = Expr | float
 
 
 class QubitPlacementError(Exception):


### PR DESCRIPTION
# Description
Tests fail with version >=1.6.0 because it seems they don't handle dependencies correctly. Probably need to create an issue on their end. But could be addressed in our own code. This is the fix for now.

Going forward probably best to pin to a specific version anyway.

# Related issues

Resolves #106 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
