### PR TITLE
Update qiskit-aqt-provider to 1.8.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ types-requests = "*"
 pydantic = "^2.0"
 networkx = "^3.0"
 sympy = ">=1.6"
-qiskit-aqt-provider = "1.5.0"
+qiskit-aqt-provider = "~1.8.1"
 
 [tool.poetry.group.tests]
 optional = true
@@ -44,6 +44,7 @@ pytest-timeout = ">=1.4.2,<3.0.0"
 hypothesis = "*"
 requests_mock = "*"
 numpy = "*"
+qiskit-aqt-provider = {version = "~1.8.1", extras = ["test"]}
 
 [tool.poetry.group.mypy]
 optional = true

--- a/pytket/extensions/aqt/backends/aqt_api.py
+++ b/pytket/extensions/aqt/backends/aqt_api.py
@@ -204,10 +204,10 @@ class AqtMockApi(AqtApi):
 
 def _aqt_job_from_pytket_aqt_job(
     job: PytketAqtJob,
-) -> api_models.JobSubmission:
-    """Create AQT JobSubmission from a list of circuits
+) -> api_models.SubmitJobRequest:
+    """Create AQT SubmitJobRequest from a list of circuits
     and corresponding numbers of shots"""
-    return api_models.JobSubmission(
+    return api_models.SubmitJobRequest(
         job_type="quantum_circuit",
         label="pytket",
         payload=api_models.QuantumCircuits(


### PR DESCRIPTION
# Description

Updates the Qiskit AQT Provider to the latest version, so that it works better with the latest version of the API and benefits from a few other new developments. 

This pins the dependency to the minor version, which will remain backwards compatible. The Qiskit provider doesn't strictly follow semver.

# Related issues

N/A

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
