### PR TITLE
fix: don't treat two arg barriers as gates for validation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 0.38.0
 ------
 
+* fix validation error (barrier treated as gate)
 * drop Python 3.10
 
 0.37.0 (March 2025)

--- a/pytket/extensions/aqt/multi_zone_architecture/circuit/multizone_circuit.py
+++ b/pytket/extensions/aqt/multi_zone_architecture/circuit/multizone_circuit.py
@@ -557,7 +557,7 @@ class MultiZoneCircuit:
                     current_placement[target_zone].append(qubit)
 
                 current_qubit_to_zone[qubit] = target_zone
-            elif len(cmd.args) == 2 and optype != OpType.Measure:  # noqa: PLR2004
+            elif len(cmd.args) == 2 and optype not in (OpType.Measure, OpType.Barrier):  # noqa: PLR2004
                 qubit_1 = cmd.args[0].index[0]
                 qubit_2 = cmd.args[1].index[0]
                 current_zone = current_qubit_to_zone[qubit_1]


### PR DESCRIPTION
# Description

- Fixes a bug where barriers over two qubits could be treated as gates during validation

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
